### PR TITLE
rename mvp variable name to zMVP

### DIFF
--- a/sample/default.vert
+++ b/sample/default.vert
@@ -1,6 +1,6 @@
 #version 320 es
 
-uniform mat4 mvp;
+uniform mat4 zMVP;
 uniform mat4 local_model;
 layout(location = 0) in vec4 position;
 layout(location = 1) in vec2 uv_in;
@@ -10,6 +10,6 @@ out vec2 uv;
 void
 main()
 {
-  gl_Position = mvp * local_model * position;
+  gl_Position = zMVP * local_model * position;
   uv = uv_in;
 }


### PR DESCRIPTION
## Context

https://github.com/zigen-project/zen-remote/pull/59

## Summary

change shader variable name `mvp` to 'zMVP`

