### PR TITLE
region for expansive

### DIFF
--- a/include/zukou.h
+++ b/include/zukou.h
@@ -177,6 +177,8 @@ class Expansive final : public VirtualObject
 
   bool Init();
 
+  void SetRegion(Region *region);
+
   const std::unique_ptr<Impl> pimpl;
 };
 

--- a/src/base/expansive.cc
+++ b/src/base/expansive.cc
@@ -2,6 +2,7 @@
 
 #include "common.h"
 #include "logger.h"
+#include "region.h"
 #include "system.h"
 #include "virtual-object.h"
 
@@ -13,6 +14,12 @@ Expansive::Init()
   if (!VirtualObject::Init()) return false;
 
   return pimpl->Init(this);
+}
+
+ZUKOU_EXPORT void
+Expansive::SetRegion(Region* region)
+{
+  pimpl->SetRegion(region);
 }
 
 ZUKOU_EXPORT
@@ -70,6 +77,12 @@ Expansive::Impl::Init(VirtualObject* virtual_object)
   zgn_expansive_add_listener(proxy_, &Expansive::Impl::listener_, this);
 
   return true;
+}
+
+void
+Expansive::Impl::SetRegion(Region* region)
+{
+  zgn_expansive_set_region(proxy_, region->pimpl->proxy());
 }
 
 Expansive::Impl::Impl(System* system, IExpansiveDelegate* delegate)

--- a/src/base/expansive.h
+++ b/src/base/expansive.h
@@ -15,6 +15,8 @@ class Expansive::Impl
 
   bool Init(VirtualObject* virtual_object);
 
+  void SetRegion(Region* region);
+
   inline zgn_expansive* proxy();
 
  private:


### PR DESCRIPTION
## Context

Collision region is required in expansive 3D window.

## Summary

Enable `expansive` to set region.

## How to check behavior

