### PR TITLE
replace zigen -> zwin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @zigen-project/zigen-maintainers
+* @zwin-project/zwin-maintainers

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,15 +24,15 @@ jobs:
             libwayland-dev wayland-protocols libglm-dev libgles-dev \
             libjpeg-dev meson
 
-      - name: Clone zigen
+      - name: Clone zwin
         uses: actions/checkout@v2
         with:
-          repository: zigen-project/zigen
-          path: zigen
+          repository: zwin-project/zwin
+          path: zwin
           ref: draft
-      
-      - name: Build zigen
-        working-directory: ./zigen
+
+      - name: Build zwin
+        working-directory: ./zwin
         run: |
           meson build
           sudo ninja -C build install

--- a/README.adoc
+++ b/README.adoc
@@ -1,13 +1,13 @@
 = ZUKOU
 
-Client library for https://github.com/zigen-project[ZIGEN] windowing system
+Client library for https://github.com/zwin-project[ZIGEN] windowing system
 
 == Build & Install
 
 === Dependencies
 
-. zigen protocols +
-Please see https://github.com/zigen-project/zigen[zigen-project/zigen]
+. zwin protocols +
+Please see https://github.com/zwin-project/zwin[zwin-project/zwin]
 to build and install. +
 [yellow]#***__important__**#: Please use `draft` branch.
 
@@ -18,7 +18,7 @@ For Ubuntu, other dependencies can be installed with apt-get. See .github/workfl
 
 [source, shell]
 ----
-$ git clone https://github.com/zigen-project/zen.git
+$ git clone https://github.com/zwin-project/zen.git
 $ cd zen
 $ meson build
 $ ninja -C build install

--- a/meson.build
+++ b/meson.build
@@ -35,12 +35,12 @@ foreach func : have_funcs
 endforeach
 
 wayland_req = '>= 1.18.0'
-zigen_protocols_req = '0.0.2'
+zwin_protocols_req = '0.0.2'
 
 glm_dep = dependency('glm')
 wayland_client_dep = dependency('wayland-client', version: wayland_req)
 wayland_scanner_dep = dependency('wayland-scanner')
-zigen_protocols_dep = dependency('zigen-protocols', version: zigen_protocols_req)
+zwin_protocols_dep = dependency('zwin-protocols', version: zwin_protocols_req)
 jpeg_dep = dependency('libjpeg')
 
 public_inc = include_directories('include')

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -1,12 +1,12 @@
-_zigen_protocols_dir = zigen_protocols_dep.get_variable('pkgdatadir')
+_zwin_protocols_dir = zwin_protocols_dep.get_variable('pkgdatadir')
 _scanner_path = wayland_scanner_dep.get_variable('wayland_scanner')
 _wayland_scanner = find_program(_scanner_path)
 
 
 _protocols = {
-  'zigen': join_paths(_zigen_protocols_dir, 'zigen.xml'),
-  'zigen-gles-v32': join_paths(_zigen_protocols_dir, 'zigen-gles-v32.xml'),
-  'zigen-shell': join_paths(_zigen_protocols_dir, 'zigen-shell.xml'),
+  'zwin': join_paths(_zwin_protocols_dir, 'zwin.xml'),
+  'zwin-gles-v32': join_paths(_zwin_protocols_dir, 'zwin-gles-v32.xml'),
+  'zwin-shell': join_paths(_zwin_protocols_dir, 'zwin-shell.xml'),
 }
 
 # protocols[<protocol-name>][<type>]

--- a/src/base/bounded.cc
+++ b/src/base/bounded.cc
@@ -49,12 +49,12 @@ Bounded::Bounded(System *system, IBoundedDelegate *delegate)
 ZUKOU_EXPORT
 Bounded::~Bounded() = default;
 
-const zgn_bounded_listener Bounded::Impl::listener_ = {
+const zwn_bounded_listener Bounded::Impl::listener_ = {
     Bounded::Impl::HandleConfigure,
 };
 
 void
-Bounded::Impl::HandleConfigure(void *data, zgn_bounded * /*zgn_bounded*/,
+Bounded::Impl::HandleConfigure(void *data, zwn_bounded * /*zwn_bounded*/,
     struct wl_array *half_size, uint32_t serial)
 {
   auto self = static_cast<Bounded::Impl *>(data);
@@ -71,7 +71,7 @@ Bounded::Impl::Init(VirtualObject *virtual_object, const glm::vec3 &half_size)
   wl_array array;
   to_array(half_size, &array);
 
-  proxy_ = zgn_shell_get_bounded(
+  proxy_ = zwn_shell_get_bounded(
       system_->pimpl->shell(), virtual_object->pimpl->proxy(), &array);
   wl_array_release(&array);
 
@@ -80,7 +80,7 @@ Bounded::Impl::Init(VirtualObject *virtual_object, const glm::vec3 &half_size)
     return false;
   }
 
-  zgn_bounded_add_listener(proxy_, &Bounded::Impl::listener_, this);
+  zwn_bounded_add_listener(proxy_, &Bounded::Impl::listener_, this);
 
   return true;
 }
@@ -88,7 +88,7 @@ Bounded::Impl::Init(VirtualObject *virtual_object, const glm::vec3 &half_size)
 void
 Bounded::Impl::AckConfigure(uint32_t serial)
 {
-  zgn_bounded_ack_configure(proxy_, serial);
+  zwn_bounded_ack_configure(proxy_, serial);
 }
 
 void
@@ -100,13 +100,13 @@ Bounded::Impl::SetTitle(const std::string &title)
 void
 Bounded::Impl::SetRegion(Region *region)
 {
-  zgn_bounded_set_region(proxy_, region->pimpl->proxy());
+  zwn_bounded_set_region(proxy_, region->pimpl->proxy());
 }
 
 void
 Bounded::Impl::Move(uint32_t serial)
 {
-  zgn_bounded_move(proxy_, system_->pimpl->seat(), serial);
+  zwn_bounded_move(proxy_, system_->pimpl->seat(), serial);
 }
 
 Bounded::Impl::Impl(System *system, IBoundedDelegate *delegate)
@@ -116,7 +116,7 @@ Bounded::Impl::Impl(System *system, IBoundedDelegate *delegate)
 Bounded::Impl::~Impl()
 {
   if (proxy_) {
-    zgn_bounded_destroy(proxy_);
+    zwn_bounded_destroy(proxy_);
   }
 }
 

--- a/src/base/bounded.cc
+++ b/src/base/bounded.cc
@@ -94,7 +94,7 @@ Bounded::Impl::AckConfigure(uint32_t serial)
 void
 Bounded::Impl::SetTitle(const std::string &title)
 {
-  zgn_bounded_set_title(proxy_, title.c_str());
+  zwn_bounded_set_title(proxy_, title.c_str());
 }
 
 void

--- a/src/base/bounded.h
+++ b/src/base/bounded.h
@@ -2,7 +2,7 @@
 
 #include <zukou.h>
 
-#include <zigen-shell-client-protocol.h>
+#include <zwin-shell-client-protocol.h>
 
 #include <glm/vec3.hpp>
 
@@ -25,20 +25,20 @@ class Bounded::Impl
 
   void Move(uint32_t serial);
 
-  inline zgn_bounded* proxy();
+  inline zwn_bounded* proxy();
 
  private:
-  static const zgn_bounded_listener listener_;
-  static void HandleConfigure(void* data, zgn_bounded* zgn_bounded,
+  static const zwn_bounded_listener listener_;
+  static void HandleConfigure(void* data, zwn_bounded* zwn_bounded,
       struct wl_array* half_size, uint32_t serial);
 
   System* system_;
   IBoundedDelegate* delegate_;
 
-  zgn_bounded* proxy_ = nullptr;
+  zwn_bounded* proxy_ = nullptr;
 };
 
-inline zgn_bounded*
+inline zwn_bounded*
 Bounded::Impl::proxy()
 {
   return proxy_;

--- a/src/base/buffer.cc
+++ b/src/base/buffer.cc
@@ -19,12 +19,12 @@ Buffer::Buffer(IBufferDelegate *delegate) : pimpl(new Impl(delegate)) {}
 ZUKOU_EXPORT
 Buffer::~Buffer() = default;
 
-const zgn_buffer_listener Buffer::Impl::listener_ = {
+const zwn_buffer_listener Buffer::Impl::listener_ = {
     Buffer::Impl::HandleRelease,
 };
 
 void
-Buffer::Impl::HandleRelease(void *data, zgn_buffer * /*zgn_buffer*/)
+Buffer::Impl::HandleRelease(void *data, zwn_buffer * /*zwn_buffer*/)
 {
   auto self = static_cast<Buffer::Impl *>(data);
 
@@ -39,18 +39,18 @@ Buffer::Impl::Init(ShmPool *pool, off_t offset, off_t size)
   to_array(offset, &offset_wl_array);
   to_array(size, &size_wl_array);
 
-  proxy_ = zgn_shm_pool_create_buffer(
+  proxy_ = zwn_shm_pool_create_buffer(
       pool->pimpl->proxy(), &offset_wl_array, &size_wl_array);
 
   wl_array_release(&offset_wl_array);
   wl_array_release(&size_wl_array);
 
   if (proxy_ == nullptr) {
-    LOG_ERROR("Failed to create zgn_buffer proxy");
+    LOG_ERROR("Failed to create zwn_buffer proxy");
     return false;
   }
 
-  zgn_buffer_add_listener(proxy_, &Buffer::Impl::listener_, this);
+  zwn_buffer_add_listener(proxy_, &Buffer::Impl::listener_, this);
 
   return true;
 }
@@ -60,7 +60,7 @@ Buffer::Impl::Impl(IBufferDelegate *delegate) : delegate_(delegate) {}
 Buffer::Impl::~Impl()
 {
   if (proxy_) {
-    zgn_buffer_destroy(proxy_);
+    zwn_buffer_destroy(proxy_);
   }
 }
 

--- a/src/base/buffer.h
+++ b/src/base/buffer.h
@@ -2,7 +2,7 @@
 
 #include <zukou.h>
 
-#include <zigen-client-protocol.h>
+#include <zwin-client-protocol.h>
 
 namespace zukou {
 
@@ -16,18 +16,18 @@ class Buffer::Impl
 
   bool Init(ShmPool *pool, off_t offset, off_t size);
 
-  inline zgn_buffer *proxy();
+  inline zwn_buffer *proxy();
 
  private:
-  static const zgn_buffer_listener listener_;
-  static void HandleRelease(void *data, zgn_buffer *zgn_buffer);
+  static const zwn_buffer_listener listener_;
+  static void HandleRelease(void *data, zwn_buffer *zwn_buffer);
 
   IBufferDelegate *delegate_;  // nullable
 
-  zgn_buffer *proxy_ = nullptr;
+  zwn_buffer *proxy_ = nullptr;
 };
 
-inline zgn_buffer *
+inline zwn_buffer *
 Buffer::Impl::proxy()
 {
   return proxy_;

--- a/src/base/expansive.cc
+++ b/src/base/expansive.cc
@@ -30,7 +30,7 @@ Expansive::Expansive(System* system, IExpansiveDelegate* delegate)
 ZUKOU_EXPORT
 Expansive::~Expansive() = default;
 
-const zgn_expansive_listener Expansive::Impl::listener_ = {
+const zwn_expansive_listener Expansive::Impl::listener_ = {
     Expansive::Impl::HandleEnter,
     Expansive::Impl::HandleLeave,
     Expansive::Impl::HandleShutdown,
@@ -38,7 +38,7 @@ const zgn_expansive_listener Expansive::Impl::listener_ = {
 
 void
 Expansive::Impl::HandleEnter(
-    void* data, struct zgn_expansive* /*zgn_expansive*/)
+    void* data, struct zwn_expansive* /*zwn_expansive*/)
 {
   auto self = static_cast<Expansive::Impl*>(data);
 
@@ -47,7 +47,7 @@ Expansive::Impl::HandleEnter(
 
 void
 Expansive::Impl::HandleLeave(
-    void* data, struct zgn_expansive* /*zgn_expansive*/)
+    void* data, struct zwn_expansive* /*zwn_expansive*/)
 {
   auto self = static_cast<Expansive::Impl*>(data);
 
@@ -56,7 +56,7 @@ Expansive::Impl::HandleLeave(
 
 void
 Expansive::Impl::HandleShutdown(
-    void* data, struct zgn_expansive* /*zgn_expansive*/)
+    void* data, struct zwn_expansive* /*zwn_expansive*/)
 {
   auto self = static_cast<Expansive::Impl*>(data);
 
@@ -66,7 +66,7 @@ Expansive::Impl::HandleShutdown(
 bool
 Expansive::Impl::Init(VirtualObject* virtual_object)
 {
-  proxy_ = zgn_shell_get_expansive(
+  proxy_ = zwn_shell_get_expansive(
       system_->pimpl->shell(), virtual_object->pimpl->proxy());
 
   if (proxy_ == nullptr) {
@@ -74,7 +74,7 @@ Expansive::Impl::Init(VirtualObject* virtual_object)
     return false;
   }
 
-  zgn_expansive_add_listener(proxy_, &Expansive::Impl::listener_, this);
+  zwn_expansive_add_listener(proxy_, &Expansive::Impl::listener_, this);
 
   return true;
 }
@@ -82,7 +82,7 @@ Expansive::Impl::Init(VirtualObject* virtual_object)
 void
 Expansive::Impl::SetRegion(Region* region)
 {
-  zgn_expansive_set_region(proxy_, region->pimpl->proxy());
+  zwn_expansive_set_region(proxy_, region->pimpl->proxy());
 }
 
 Expansive::Impl::Impl(System* system, IExpansiveDelegate* delegate)
@@ -92,7 +92,7 @@ Expansive::Impl::Impl(System* system, IExpansiveDelegate* delegate)
 Expansive::Impl::~Impl()
 {
   if (proxy_) {
-    zgn_expansive_destroy(proxy_);
+    zwn_expansive_destroy(proxy_);
   }
 }
 

--- a/src/base/expansive.h
+++ b/src/base/expansive.h
@@ -2,7 +2,7 @@
 
 #include <zukou.h>
 
-#include <zigen-shell-client-protocol.h>
+#include <zwin-shell-client-protocol.h>
 
 namespace zukou {
 
@@ -17,21 +17,21 @@ class Expansive::Impl
 
   void SetRegion(Region* region);
 
-  inline zgn_expansive* proxy();
+  inline zwn_expansive* proxy();
 
  private:
-  static const zgn_expansive_listener listener_;
-  static void HandleEnter(void* data, struct zgn_expansive* zgn_expansive);
-  static void HandleLeave(void* data, struct zgn_expansive* zgn_expansive);
-  static void HandleShutdown(void* data, struct zgn_expansive* zgn_expansive);
+  static const zwn_expansive_listener listener_;
+  static void HandleEnter(void* data, struct zwn_expansive* zwn_expansive);
+  static void HandleLeave(void* data, struct zwn_expansive* zwn_expansive);
+  static void HandleShutdown(void* data, struct zwn_expansive* zwn_expansive);
 
   System* system_;
   IExpansiveDelegate* delegate_;
 
-  zgn_expansive* proxy_;
+  zwn_expansive* proxy_;
 };
 
-inline zgn_expansive*
+inline zwn_expansive*
 Expansive::Impl::proxy()
 {
   return proxy_;

--- a/src/base/gl-base-technique.cc
+++ b/src/base/gl-base-technique.cc
@@ -76,7 +76,7 @@ GlBaseTechnique::~GlBaseTechnique() = default;
 bool
 GlBaseTechnique::Impl::Init(RenderingUnit *unit)
 {
-  proxy_ = zgn_gles_v32_create_gl_base_technique(
+  proxy_ = zwn_gles_v32_create_gl_base_technique(
       system_->pimpl->gles_v32(), unit->pimpl->proxy());
   if (proxy_ == nullptr) {
     LOG_ERROR("Failed to create base technique proxy");
@@ -89,7 +89,7 @@ GlBaseTechnique::Impl::Init(RenderingUnit *unit)
 void
 GlBaseTechnique::Impl::DrawArrays(GLenum mode, GLint first, GLsizei count)
 {
-  zgn_gl_base_technique_draw_arrays(proxy_, mode, first, count);
+  zwn_gl_base_technique_draw_arrays(proxy_, mode, first, count);
 }
 
 void
@@ -100,7 +100,7 @@ GlBaseTechnique::Impl::DrawElements(GLenum mode, GLsizei count, GLenum type,
 
   to_array(offset, &offset_wl_array);
 
-  zgn_gl_base_technique_draw_elements(proxy_, mode, count, type,
+  zwn_gl_base_technique_draw_elements(proxy_, mode, count, type,
       &offset_wl_array, element_array_buffer->pimpl->proxy());
 
   wl_array_release(&offset_wl_array);
@@ -109,20 +109,20 @@ GlBaseTechnique::Impl::DrawElements(GLenum mode, GLsizei count, GLenum type,
 void
 GlBaseTechnique::Impl::Bind(GlProgram *program)
 {
-  zgn_gl_base_technique_bind_program(proxy_, program->pimpl->proxy());
+  zwn_gl_base_technique_bind_program(proxy_, program->pimpl->proxy());
 }
 
 void
 GlBaseTechnique::Impl::Bind(GlVertexArray *vertex_array)
 {
-  zgn_gl_base_technique_bind_vertex_array(proxy_, vertex_array->pimpl->proxy());
+  zwn_gl_base_technique_bind_vertex_array(proxy_, vertex_array->pimpl->proxy());
 }
 
 void
 GlBaseTechnique::Impl::Bind(uint32_t binding, std::string name,
     GlTexture *texture, GLenum target, GlSampler *sampler)
 {
-  zgn_gl_base_technique_bind_texture(proxy_, binding, name.c_str(),
+  zwn_gl_base_technique_bind_texture(proxy_, binding, name.c_str(),
       texture->pimpl->proxy(), target, sampler->pimpl->proxy());
 }
 
@@ -132,16 +132,16 @@ GlBaseTechnique::Impl::UniformVector(uint32_t location, const std::string &name,
 {
   wl_array array;
 
-  enum zgn_gl_base_technique_uniform_variable_type zgn_type;
+  enum zwn_gl_base_technique_uniform_variable_type zwn_type;
   switch (type) {
     case kFloat:
-      zgn_type = ZGN_GL_BASE_TECHNIQUE_UNIFORM_VARIABLE_TYPE_FLOAT;
+      zwn_type = ZWN_GL_BASE_TECHNIQUE_UNIFORM_VARIABLE_TYPE_FLOAT;
       break;
     case kInt:
-      zgn_type = ZGN_GL_BASE_TECHNIQUE_UNIFORM_VARIABLE_TYPE_INT;
+      zwn_type = ZWN_GL_BASE_TECHNIQUE_UNIFORM_VARIABLE_TYPE_INT;
       break;
     case kUint:
-      zgn_type = ZGN_GL_BASE_TECHNIQUE_UNIFORM_VARIABLE_TYPE_UINT;
+      zwn_type = ZWN_GL_BASE_TECHNIQUE_UNIFORM_VARIABLE_TYPE_UINT;
       break;
   }
 
@@ -153,8 +153,8 @@ GlBaseTechnique::Impl::UniformVector(uint32_t location, const std::string &name,
     std::memcpy(data, value, value_size);
   }
 
-  zgn_gl_base_technique_uniform_vector(
-      proxy_, location, name.c_str(), zgn_type, size, count, &array);
+  zwn_gl_base_technique_uniform_vector(
+      proxy_, location, name.c_str(), zwn_type, size, count, &array);
 
   wl_array_release(&array);
 }
@@ -172,7 +172,7 @@ GlBaseTechnique::Impl::UniformMatrix(uint32_t location, const std::string &name,
     std::memcpy(data, value, value_size);
   }
 
-  zgn_gl_base_technique_uniform_matrix(
+  zwn_gl_base_technique_uniform_matrix(
       proxy_, location, name.c_str(), col, row, count, transpose, &array);
 
   wl_array_release(&array);
@@ -183,7 +183,7 @@ GlBaseTechnique::Impl::Impl(System *system) : system_(system) {}
 GlBaseTechnique::Impl::~Impl()
 {
   if (proxy_) {
-    zgn_gl_base_technique_destroy(proxy_);
+    zwn_gl_base_technique_destroy(proxy_);
   }
 }
 

--- a/src/base/gl-base-technique.h
+++ b/src/base/gl-base-technique.h
@@ -2,7 +2,7 @@
 
 #include <zukou.h>
 
-#include <zigen-gles-v32-client-protocol.h>
+#include <zwin-gles-v32-client-protocol.h>
 
 namespace zukou {
 
@@ -37,7 +37,7 @@ class GlBaseTechnique::Impl
  private:
   System *system_;
 
-  zgn_gl_base_technique *proxy_ = nullptr;
+  zwn_gl_base_technique *proxy_ = nullptr;
 };
 
 }  // namespace zukou

--- a/src/base/gl-buffer.cc
+++ b/src/base/gl-buffer.cc
@@ -28,9 +28,9 @@ GlBuffer::~GlBuffer() = default;
 bool
 GlBuffer::Impl::Init()
 {
-  proxy_ = zgn_gles_v32_create_gl_buffer(system_->pimpl->gles_v32());
+  proxy_ = zwn_gles_v32_create_gl_buffer(system_->pimpl->gles_v32());
   if (proxy_ == nullptr) {
-    LOG_ERROR("Failed to creat zgn_gl_buffer proxy");
+    LOG_ERROR("Failed to creat zwn_gl_buffer proxy");
     return false;
   }
 
@@ -40,7 +40,7 @@ GlBuffer::Impl::Init()
 void
 GlBuffer::Impl::Data(GLenum target, Buffer *buffer, GLenum usage)
 {
-  zgn_gl_buffer_data(proxy_, target, buffer->pimpl->proxy(), usage);
+  zwn_gl_buffer_data(proxy_, target, buffer->pimpl->proxy(), usage);
 }
 
 GlBuffer::Impl::Impl(System *system) : system_(system) {}
@@ -48,7 +48,7 @@ GlBuffer::Impl::Impl(System *system) : system_(system) {}
 GlBuffer::Impl::~Impl()
 {
   if (proxy_) {
-    zgn_gl_buffer_destroy(proxy_);
+    zwn_gl_buffer_destroy(proxy_);
   }
 }
 

--- a/src/base/gl-buffer.h
+++ b/src/base/gl-buffer.h
@@ -2,7 +2,7 @@
 
 #include <zukou.h>
 
-#include <zigen-gles-v32-client-protocol.h>
+#include <zwin-gles-v32-client-protocol.h>
 
 namespace zukou {
 
@@ -18,14 +18,14 @@ class GlBuffer::Impl
 
   void Data(GLenum target, Buffer* buffer, GLenum usage);
 
-  inline zgn_gl_buffer* proxy();
+  inline zwn_gl_buffer* proxy();
 
  private:
   System* system_;
-  zgn_gl_buffer* proxy_ = nullptr;
+  zwn_gl_buffer* proxy_ = nullptr;
 };
 
-inline zgn_gl_buffer*
+inline zwn_gl_buffer*
 GlBuffer::Impl::proxy()
 {
   return proxy_;

--- a/src/base/gl-program.cc
+++ b/src/base/gl-program.cc
@@ -34,9 +34,9 @@ GlProgram::~GlProgram() = default;
 bool
 GlProgram::Impl::Init()
 {
-  proxy_ = zgn_gles_v32_create_gl_program(system_->pimpl->gles_v32());
+  proxy_ = zwn_gles_v32_create_gl_program(system_->pimpl->gles_v32());
   if (proxy_ == nullptr) {
-    LOG_ERROR("Failed to create zgn_gl_program proxy");
+    LOG_ERROR("Failed to create zwn_gl_program proxy");
     return false;
   }
 
@@ -46,13 +46,13 @@ GlProgram::Impl::Init()
 void
 GlProgram::Impl::AttachShader(GlShader *shader)
 {
-  zgn_gl_program_attach_shader(proxy_, shader->pimpl->proxy());
+  zwn_gl_program_attach_shader(proxy_, shader->pimpl->proxy());
 }
 
 void
 GlProgram::Impl::Link()
 {
-  zgn_gl_program_link(proxy_);
+  zwn_gl_program_link(proxy_);
 }
 
 GlProgram::Impl::Impl(System *system) : system_(system) {}
@@ -60,7 +60,7 @@ GlProgram::Impl::Impl(System *system) : system_(system) {}
 GlProgram::Impl::~Impl()
 {
   if (proxy_) {
-    zgn_gl_program_destroy(proxy_);
+    zwn_gl_program_destroy(proxy_);
   }
 }
 

--- a/src/base/gl-program.h
+++ b/src/base/gl-program.h
@@ -2,7 +2,7 @@
 
 #include <zukou.h>
 
-#include <zigen-gles-v32-client-protocol.h>
+#include <zwin-gles-v32-client-protocol.h>
 
 namespace zukou {
 
@@ -20,14 +20,14 @@ class GlProgram::Impl
 
   void Link();
 
-  inline zgn_gl_program *proxy();
+  inline zwn_gl_program *proxy();
 
  private:
   System *system_;
-  zgn_gl_program *proxy_ = nullptr;
+  zwn_gl_program *proxy_ = nullptr;
 };
 
-inline zgn_gl_program *
+inline zwn_gl_program *
 GlProgram::Impl::proxy()
 {
   return proxy_;

--- a/src/base/gl-sampler.cc
+++ b/src/base/gl-sampler.cc
@@ -34,9 +34,9 @@ GlSampler::~GlSampler() = default;
 bool
 GlSampler::Impl::Init()
 {
-  proxy_ = zgn_gles_v32_create_gl_sampler(system_->pimpl->gles_v32());
+  proxy_ = zwn_gles_v32_create_gl_sampler(system_->pimpl->gles_v32());
   if (proxy_ == nullptr) {
-    LOG_ERROR("Failed to create zgn_gl_shader proxy");
+    LOG_ERROR("Failed to create zwn_gl_shader proxy");
     return false;
   }
 
@@ -46,7 +46,7 @@ GlSampler::Impl::Init()
 void
 GlSampler::Impl::Parameteri(GLenum pname, GLint param)
 {
-  zgn_gl_sampler_parameteri(proxy_, pname, param);
+  zwn_gl_sampler_parameteri(proxy_, pname, param);
 }
 
 void
@@ -55,7 +55,7 @@ GlSampler::Impl::Parameterf(GLenum pname, GLfloat param)
   wl_array param_wl_array;
   to_array(param, &param_wl_array);
 
-  zgn_gl_sampler_parameterf(proxy_, pname, &param_wl_array);
+  zwn_gl_sampler_parameterf(proxy_, pname, &param_wl_array);
 
   wl_array_release(&param_wl_array);
 }
@@ -65,7 +65,7 @@ GlSampler::Impl::Impl(System *system) : system_(system) {}
 GlSampler::Impl::~Impl()
 {
   if (proxy_) {
-    zgn_gl_sampler_destroy(proxy_);
+    zwn_gl_sampler_destroy(proxy_);
   }
 }
 

--- a/src/base/gl-sampler.h
+++ b/src/base/gl-sampler.h
@@ -2,7 +2,7 @@
 
 #include <zukou.h>
 
-#include <zigen-gles-v32-client-protocol.h>
+#include <zwin-gles-v32-client-protocol.h>
 
 namespace zukou {
 
@@ -20,14 +20,14 @@ class GlSampler::Impl
 
   void Parameterf(GLenum pname, GLfloat param);
 
-  inline zgn_gl_sampler *proxy();
+  inline zwn_gl_sampler *proxy();
 
  private:
   System *system_;
-  zgn_gl_sampler *proxy_ = nullptr;
+  zwn_gl_sampler *proxy_ = nullptr;
 };
 
-inline zgn_gl_sampler *
+inline zwn_gl_sampler *
 GlSampler::Impl::proxy()
 {
   return proxy_;

--- a/src/base/gl-shader.cc
+++ b/src/base/gl-shader.cc
@@ -42,11 +42,11 @@ GlShader::Impl::Init(GLenum type, const std::string &source)
   pool_.Init(fd_, source.size());
   buffer_.Init(&pool_, 0, source.size());
 
-  proxy_ = zgn_gles_v32_create_gl_shader(
+  proxy_ = zwn_gles_v32_create_gl_shader(
       system_->pimpl->gles_v32(), buffer_.pimpl->proxy(), type);
 
   if (proxy_ == nullptr) {
-    LOG_ERROR("Failed to creat zgn_gl_shader proxy");
+    LOG_ERROR("Failed to creat zwn_gl_shader proxy");
     close(fd_);
     fd_ = 0;
     return false;
@@ -61,7 +61,7 @@ GlShader::Impl::Impl(System *system) : system_(system), pool_(system), buffer_()
 GlShader::Impl::~Impl()
 {
   if (proxy_) {
-    zgn_gl_shader_destroy(proxy_);
+    zwn_gl_shader_destroy(proxy_);
   }
 
   if (fd_ != 0) close(fd_);

--- a/src/base/gl-shader.h
+++ b/src/base/gl-shader.h
@@ -2,7 +2,7 @@
 
 #include <zukou.h>
 
-#include <zigen-gles-v32-client-protocol.h>
+#include <zwin-gles-v32-client-protocol.h>
 
 namespace zukou {
 
@@ -16,18 +16,18 @@ class GlShader::Impl
 
   bool Init(GLenum type, const std::string& source);
 
-  inline zgn_gl_shader* proxy();
+  inline zwn_gl_shader* proxy();
 
  private:
   System* system_;
-  zgn_gl_shader* proxy_ = nullptr;
+  zwn_gl_shader* proxy_ = nullptr;
 
   ShmPool pool_;
   Buffer buffer_;
   int fd_ = 0;
 };
 
-inline zgn_gl_shader*
+inline zwn_gl_shader*
 GlShader::Impl::proxy()
 {
   return proxy_;

--- a/src/base/gl-texture.cc
+++ b/src/base/gl-texture.cc
@@ -37,9 +37,9 @@ GlTexture::~GlTexture() = default;
 bool
 GlTexture::Impl::Init()
 {
-  proxy_ = zgn_gles_v32_create_gl_texture(system_->pimpl->gles_v32());
+  proxy_ = zwn_gles_v32_create_gl_texture(system_->pimpl->gles_v32());
   if (proxy_ == nullptr) {
-    LOG_ERROR("Failed to create zgn_gl_texture proxy");
+    LOG_ERROR("Failed to create zwn_gl_texture proxy");
     return false;
   }
 
@@ -51,14 +51,14 @@ GlTexture::Impl::Image2D(GLenum target, GLint level, GLint internal_format,
     GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type,
     Buffer *buffer)
 {
-  zgn_gl_texture_image_2d(proxy_, target, level, internal_format, width, height,
+  zwn_gl_texture_image_2d(proxy_, target, level, internal_format, width, height,
       border, format, type, buffer->pimpl->proxy());
 }
 
 void
 GlTexture::Impl::GenerateMipmap(GLenum target)
 {
-  zgn_gl_texture_generate_mipmap(proxy_, target);
+  zwn_gl_texture_generate_mipmap(proxy_, target);
 }
 
 GlTexture::Impl::Impl(System *system) : system_(system) {}
@@ -66,7 +66,7 @@ GlTexture::Impl::Impl(System *system) : system_(system) {}
 GlTexture::Impl::~Impl()
 {
   if (proxy_) {
-    zgn_gl_texture_destroy(proxy_);
+    zwn_gl_texture_destroy(proxy_);
   }
 }
 

--- a/src/base/gl-texture.h
+++ b/src/base/gl-texture.h
@@ -2,7 +2,7 @@
 
 #include <zukou.h>
 
-#include <zigen-gles-v32-client-protocol.h>
+#include <zwin-gles-v32-client-protocol.h>
 
 namespace zukou {
 
@@ -21,14 +21,14 @@ class GlTexture::Impl
 
   void GenerateMipmap(GLenum target);
 
-  inline zgn_gl_texture *proxy();
+  inline zwn_gl_texture *proxy();
 
  private:
   System *system_;
-  zgn_gl_texture *proxy_;
+  zwn_gl_texture *proxy_;
 };
 
-inline zgn_gl_texture *
+inline zwn_gl_texture *
 GlTexture::Impl::proxy()
 {
   return proxy_;

--- a/src/base/gl-vertex-array.cc
+++ b/src/base/gl-vertex-array.cc
@@ -43,9 +43,9 @@ GlVertexArray::~GlVertexArray() = default;
 bool
 GlVertexArray::Impl::Init()
 {
-  proxy_ = zgn_gles_v32_create_gl_vertex_array(system_->pimpl->gles_v32());
+  proxy_ = zwn_gles_v32_create_gl_vertex_array(system_->pimpl->gles_v32());
   if (proxy_ == nullptr) {
-    LOG_ERROR("Failed to create zgn_gl_vertex_array proxy");
+    LOG_ERROR("Failed to create zwn_gl_vertex_array proxy");
     return false;
   }
 
@@ -55,13 +55,13 @@ GlVertexArray::Impl::Init()
 void
 GlVertexArray::Impl::Enable(GLuint index)
 {
-  zgn_gl_vertex_array_enable_vertex_attrib_array(proxy_, index);
+  zwn_gl_vertex_array_enable_vertex_attrib_array(proxy_, index);
 }
 
 void
 GlVertexArray::Impl::Disable(GLuint index)
 {
-  zgn_gl_vertex_array_disable_vertex_attrib_array(proxy_, index);
+  zwn_gl_vertex_array_disable_vertex_attrib_array(proxy_, index);
 }
 
 void
@@ -72,7 +72,7 @@ GlVertexArray::Impl::VertexAttribPointer(GLuint index, GLint size, GLenum type,
 
   to_array(offset, &offset_wl_array);
 
-  zgn_gl_vertex_array_vertex_attrib_pointer(proxy_, index, size, type,
+  zwn_gl_vertex_array_vertex_attrib_pointer(proxy_, index, size, type,
       normalized, stride, &offset_wl_array, gl_buffer->pimpl->proxy());
 
   wl_array_release(&offset_wl_array);
@@ -83,7 +83,7 @@ GlVertexArray::Impl::Impl(System *system) : system_(system) {}
 GlVertexArray::Impl::~Impl()
 {
   if (proxy_) {
-    zgn_gl_vertex_array_destroy(proxy_);
+    zwn_gl_vertex_array_destroy(proxy_);
   }
 }
 

--- a/src/base/gl-vertex-array.h
+++ b/src/base/gl-vertex-array.h
@@ -2,7 +2,7 @@
 
 #include <zukou.h>
 
-#include <zigen-gles-v32-client-protocol.h>
+#include <zwin-gles-v32-client-protocol.h>
 
 namespace zukou {
 
@@ -24,14 +24,14 @@ class GlVertexArray::Impl
       GLboolean normalized, GLsizei stride, uint64_t offset,
       GlBuffer *gl_buffer);
 
-  inline zgn_gl_vertex_array *proxy();
+  inline zwn_gl_vertex_array *proxy();
 
  private:
   System *system_;
-  zgn_gl_vertex_array *proxy_;
+  zwn_gl_vertex_array *proxy_;
 };
 
-inline zgn_gl_vertex_array *
+inline zwn_gl_vertex_array *
 GlVertexArray::Impl::proxy()
 {
   return proxy_;

--- a/src/base/region.cc
+++ b/src/base/region.cc
@@ -36,7 +36,7 @@ Region::Impl::AddCuboid(const glm::vec3& half_size, const glm::vec3& center,
   to_array(center, &center_wl_array);
   to_array(quaternion, &quaternion_wl_array);
 
-  zgn_region_add_cuboid(
+  zwn_region_add_cuboid(
       proxy_, &half_size_wl_array, &center_wl_array, &quaternion_wl_array);
 
   wl_array_release(&half_size_wl_array);
@@ -47,7 +47,7 @@ Region::Impl::AddCuboid(const glm::vec3& half_size, const glm::vec3& center,
 bool
 Region::Impl::Init()
 {
-  proxy_ = zgn_compositor_create_region(system_->pimpl->compositor());
+  proxy_ = zwn_compositor_create_region(system_->pimpl->compositor());
   if (proxy_ == nullptr) {
     LOG_ERROR("Failed to create region proxy");
     return false;
@@ -61,7 +61,7 @@ Region::Impl::Impl(System* system) : system_(system) {}
 Region::Impl::~Impl()
 {
   if (proxy_) {
-    zgn_region_destroy(proxy_);
+    zwn_region_destroy(proxy_);
   }
 }
 

--- a/src/base/region.h
+++ b/src/base/region.h
@@ -2,7 +2,7 @@
 
 #include <zukou.h>
 
-#include <zigen-client-protocol.h>
+#include <zwin-client-protocol.h>
 
 namespace zukou {
 
@@ -18,15 +18,15 @@ class Region::Impl
   void AddCuboid(const glm::vec3 &half_size, const glm::vec3 &center,
       const glm::quat &quaternion);
 
-  inline zgn_region *proxy();
+  inline zwn_region *proxy();
 
  private:
   System *system_;
 
-  zgn_region *proxy_ = nullptr;
+  zwn_region *proxy_ = nullptr;
 };
 
-inline zgn_region *
+inline zwn_region *
 Region::Impl::proxy()
 {
   return proxy_;

--- a/src/base/rendering-unit.cc
+++ b/src/base/rendering-unit.cc
@@ -22,7 +22,7 @@ RenderingUnit::~RenderingUnit() = default;
 bool
 RenderingUnit::Impl::Init(VirtualObject* virtual_object)
 {
-  proxy_ = zgn_gles_v32_create_rendering_unit(
+  proxy_ = zwn_gles_v32_create_rendering_unit(
       system_->pimpl->gles_v32(), virtual_object->pimpl->proxy());
   if (proxy_ == nullptr) {
     LOG_ERROR("Failed to create rendering unit proxy");
@@ -37,7 +37,7 @@ RenderingUnit::Impl::Impl(System* system) : system_(system) {}
 RenderingUnit::Impl::~Impl()
 {
   if (proxy_) {
-    zgn_rendering_unit_destroy(proxy_);
+    zwn_rendering_unit_destroy(proxy_);
   }
 }
 

--- a/src/base/rendering-unit.h
+++ b/src/base/rendering-unit.h
@@ -2,7 +2,7 @@
 
 #include <zukou.h>
 
-#include <zigen-gles-v32-client-protocol.h>
+#include <zwin-gles-v32-client-protocol.h>
 
 namespace zukou {
 
@@ -15,15 +15,15 @@ class RenderingUnit::Impl
 
   bool Init(VirtualObject* virtual_object_);
 
-  inline zgn_rendering_unit* proxy();
+  inline zwn_rendering_unit* proxy();
 
  private:
   System* system_;
 
-  zgn_rendering_unit* proxy_ = nullptr;
+  zwn_rendering_unit* proxy_ = nullptr;
 };
 
-inline zgn_rendering_unit*
+inline zwn_rendering_unit*
 RenderingUnit::Impl::proxy()
 {
   return proxy_;

--- a/src/base/shm-pool.cc
+++ b/src/base/shm-pool.cc
@@ -25,7 +25,7 @@ ShmPool::Impl::Init(int fd, off_t size)
   wl_array array;
   to_array(size, &array);
 
-  proxy_ = zgn_shm_create_pool(system_->pimpl->shm(), fd, &array);
+  proxy_ = zwn_shm_create_pool(system_->pimpl->shm(), fd, &array);
   wl_array_release(&array);
 
   if (proxy_ == nullptr) {
@@ -41,7 +41,7 @@ ShmPool::Impl::Impl(System *system) : system_(system) {}
 ShmPool::Impl::~Impl()
 {
   if (proxy_) {
-    zgn_shm_pool_destroy(proxy_);
+    zwn_shm_pool_destroy(proxy_);
   }
 }
 

--- a/src/base/shm-pool.h
+++ b/src/base/shm-pool.h
@@ -2,7 +2,7 @@
 
 #include <zukou.h>
 
-#include <zigen-client-protocol.h>
+#include <zwin-client-protocol.h>
 
 namespace zukou {
 
@@ -15,14 +15,14 @@ class ShmPool::Impl
 
   bool Init(int fd, off_t size);
 
-  inline zgn_shm_pool* proxy();
+  inline zwn_shm_pool* proxy();
 
  private:
   System* system_;
-  zgn_shm_pool* proxy_ = nullptr;
+  zwn_shm_pool* proxy_ = nullptr;
 };
 
-zgn_shm_pool*
+zwn_shm_pool*
 ShmPool::Impl::proxy()
 {
   return proxy_;

--- a/src/base/virtual-object.cc
+++ b/src/base/virtual-object.cc
@@ -39,7 +39,7 @@ const wl_callback_listener VirtualObject::Impl::callback_listener_ = {
 bool
 VirtualObject::Impl::Init()
 {
-  proxy_ = zgn_compositor_create_virtual_object(system_->pimpl->compositor());
+  proxy_ = zwn_compositor_create_virtual_object(system_->pimpl->compositor());
   if (proxy_ == nullptr) {
     LOG_ERROR("Failed to create virtual object proxy");
     return false;
@@ -53,7 +53,7 @@ VirtualObject::Impl::Init()
 void
 VirtualObject::Impl::Commit()
 {
-  zgn_virtual_object_commit(proxy_);
+  zwn_virtual_object_commit(proxy_);
 }
 
 void
@@ -61,7 +61,7 @@ VirtualObject::Impl::NextFrame()
 {
   if (callback_) return;
 
-  callback_ = zgn_virtual_object_frame(proxy_);
+  callback_ = zwn_virtual_object_frame(proxy_);
   wl_callback_add_listener(
       callback_, &VirtualObject::Impl::callback_listener_, this);
 }
@@ -89,7 +89,7 @@ VirtualObject::Impl::~Impl()
   }
 
   if (proxy_) {
-    zgn_virtual_object_destroy(proxy_);
+    zwn_virtual_object_destroy(proxy_);
   }
 }
 

--- a/src/base/virtual-object.h
+++ b/src/base/virtual-object.h
@@ -3,7 +3,7 @@
 #include <zukou.h>
 
 #include <wayland-client.h>
-#include <zigen-client-protocol.h>
+#include <zwin-client-protocol.h>
 
 namespace zukou {
 
@@ -20,7 +20,7 @@ class VirtualObject::Impl
 
   void NextFrame();
 
-  inline zgn_virtual_object* proxy();
+  inline zwn_virtual_object* proxy();
 
  private:
   static const wl_callback_listener callback_listener_;
@@ -30,11 +30,11 @@ class VirtualObject::Impl
   System* system_;
   IVirtualObjectDelegate* delegate_;
 
-  zgn_virtual_object* proxy_ = nullptr;
+  zwn_virtual_object* proxy_ = nullptr;
   wl_callback* callback_ = nullptr;
 };
 
-inline zgn_virtual_object*
+inline zwn_virtual_object*
 VirtualObject::Impl::proxy()
 {
   return proxy_;

--- a/src/meson.build
+++ b/src/meson.build
@@ -20,12 +20,12 @@ _source = [
   'base/expansive.cc',
   'base/virtual-object.cc',
 
-  protocols['zigen']['private-code'],
-  protocols['zigen']['client-header'],
-  protocols['zigen-shell']['private-code'],
-  protocols['zigen-shell']['client-header'],
-  protocols['zigen-gles-v32']['private-code'],
-  protocols['zigen-gles-v32']['client-header'],
+  protocols['zwin']['private-code'],
+  protocols['zwin']['client-header'],
+  protocols['zwin-shell']['private-code'],
+  protocols['zwin-shell']['client-header'],
+  protocols['zwin-gles-v32']['private-code'],
+  protocols['zwin-gles-v32']['client-header'],
 ]
 
 _zukou_deps = [

--- a/src/system.cc
+++ b/src/system.cc
@@ -12,7 +12,7 @@
 
 namespace zukou {
 
-const zgn_ray_listener System::Impl::ray_listener_ = {
+const zwn_ray_listener System::Impl::ray_listener_ = {
     System::Impl::HandleRayEnter,
     System::Impl::HandleRayLeave,
     System::Impl::HandleRayMotion,
@@ -25,8 +25,8 @@ const zgn_ray_listener System::Impl::ray_listener_ = {
 };
 
 void
-System::Impl::HandleRayEnter(void *data, struct zgn_ray * /*zgn_ray*/,
-    uint32_t serial, struct zgn_virtual_object *virtual_object_proxy,
+System::Impl::HandleRayEnter(void *data, struct zwn_ray * /*zwn_ray*/,
+    uint32_t serial, struct zwn_virtual_object *virtual_object_proxy,
     struct wl_array *origin_wl_array, struct wl_array *direction_wl_array)
 {
   auto self = static_cast<System::Impl *>(data);
@@ -42,8 +42,8 @@ System::Impl::HandleRayEnter(void *data, struct zgn_ray * /*zgn_ray*/,
 }
 
 void
-System::Impl::HandleRayLeave(void *data, struct zgn_ray * /*zgn_ray*/,
-    uint32_t serial, struct zgn_virtual_object *virtual_object_proxy)
+System::Impl::HandleRayLeave(void *data, struct zwn_ray * /*zwn_ray*/,
+    uint32_t serial, struct zwn_virtual_object *virtual_object_proxy)
 {
   auto self = static_cast<System::Impl *>(data);
   if (!self->delegate_) return;
@@ -55,7 +55,7 @@ System::Impl::HandleRayLeave(void *data, struct zgn_ray * /*zgn_ray*/,
 }
 
 void
-System::Impl::HandleRayMotion(void *data, struct zgn_ray * /*zgn_ray*/,
+System::Impl::HandleRayMotion(void *data, struct zwn_ray * /*zwn_ray*/,
     uint32_t time, struct wl_array *origin_wl_array,
     struct wl_array *direction_wl_array)
 {
@@ -70,16 +70,16 @@ System::Impl::HandleRayMotion(void *data, struct zgn_ray * /*zgn_ray*/,
 }
 
 void
-System::Impl::HandleRayButton(void *data, struct zgn_ray * /*zgn_ray*/,
+System::Impl::HandleRayButton(void *data, struct zwn_ray * /*zwn_ray*/,
     uint32_t serial, uint32_t time, uint32_t button, uint32_t state)
 {
   auto self = static_cast<System::Impl *>(data);
   if (!self->delegate_) return;
 
   bool pressed;
-  if (state == ZGN_RAY_BUTTON_STATE_PRESSED) {
+  if (state == ZWN_RAY_BUTTON_STATE_PRESSED) {
     pressed = true;
-  } else if (state == ZGN_RAY_BUTTON_STATE_RELEASED) {
+  } else if (state == ZWN_RAY_BUTTON_STATE_RELEASED) {
     pressed = false;
   } else {
     assert(false && "unknown ray button state");
@@ -88,13 +88,13 @@ System::Impl::HandleRayButton(void *data, struct zgn_ray * /*zgn_ray*/,
 }
 
 void
-System::Impl::HandleRayAxis(void *data, struct zgn_ray * /*zgn_ray*/,
+System::Impl::HandleRayAxis(void *data, struct zwn_ray * /*zwn_ray*/,
     uint32_t /*time*/, uint32_t axis, wl_fixed_t value)
 {
   auto self = static_cast<System::Impl *>(data);
   if (!self->delegate_) return;
 
-  if (axis == ZGN_RAY_AXIS_HORIZONTAL_SCROLL) {
+  if (axis == ZWN_RAY_AXIS_HORIZONTAL_SCROLL) {
     self->ray_axis_event_.horizontal += wl_fixed_to_double(value);
   } else {
     self->ray_axis_event_.vertical += wl_fixed_to_double(value);
@@ -103,25 +103,25 @@ System::Impl::HandleRayAxis(void *data, struct zgn_ray * /*zgn_ray*/,
 
 void
 System::Impl::HandleRayAxisSource(
-    void *data, struct zgn_ray * /*zgn_ray*/, uint32_t axis_source)
+    void *data, struct zwn_ray * /*zwn_ray*/, uint32_t axis_source)
 {
   auto self = static_cast<System::Impl *>(data);
   if (!self->delegate_) return;
 
   switch (axis_source) {
-    case ZGN_RAY_AXIS_SOURCE_WHEEL:
+    case ZWN_RAY_AXIS_SOURCE_WHEEL:
       self->ray_axis_event_.source = RayAxisEvent::kWheel;
       return;
 
-    case ZGN_RAY_AXIS_SOURCE_FINGER:
+    case ZWN_RAY_AXIS_SOURCE_FINGER:
       self->ray_axis_event_.source = RayAxisEvent::kFinger;
       return;
 
-    case ZGN_RAY_AXIS_SOURCE_CONTINUOUS:
+    case ZWN_RAY_AXIS_SOURCE_CONTINUOUS:
       self->ray_axis_event_.source = RayAxisEvent::kContinuous;
       return;
 
-    case ZGN_RAY_AXIS_SOURCE_WHEEL_TILT:
+    case ZWN_RAY_AXIS_SOURCE_WHEEL_TILT:
       self->ray_axis_event_.source = RayAxisEvent::kWheelTilt;
       return;
 
@@ -132,12 +132,12 @@ System::Impl::HandleRayAxisSource(
 
 void
 System::Impl::HandleRayAxisStop(
-    void *data, struct zgn_ray * /*zgn_ray*/, uint32_t /*time*/, uint32_t axis)
+    void *data, struct zwn_ray * /*zwn_ray*/, uint32_t /*time*/, uint32_t axis)
 {
   auto self = static_cast<System::Impl *>(data);
   if (!self->delegate_) return;
 
-  if (axis == ZGN_RAY_AXIS_HORIZONTAL_SCROLL) {
+  if (axis == ZWN_RAY_AXIS_HORIZONTAL_SCROLL) {
     self->ray_axis_event_.stop_horizontal = true;
   } else {
     self->ray_axis_event_.stop_vertical = true;
@@ -146,12 +146,12 @@ System::Impl::HandleRayAxisStop(
 
 void
 System::Impl::HandleRayAxisDiscrete(
-    void *data, struct zgn_ray * /*zgn_ray*/, uint32_t axis, int32_t discrete)
+    void *data, struct zwn_ray * /*zwn_ray*/, uint32_t axis, int32_t discrete)
 {
   auto self = static_cast<System::Impl *>(data);
   if (!self->delegate_) return;
 
-  if (axis == ZGN_RAY_AXIS_HORIZONTAL_SCROLL) {
+  if (axis == ZWN_RAY_AXIS_HORIZONTAL_SCROLL) {
     self->ray_axis_event_.discrete_horizontal += discrete;
   } else {
     self->ray_axis_event_.discrete_vertical += discrete;
@@ -159,7 +159,7 @@ System::Impl::HandleRayAxisDiscrete(
 }
 
 void
-System::Impl::HandleRayFrame(void *data, struct zgn_ray * /*zgn_ray*/)
+System::Impl::HandleRayFrame(void *data, struct zwn_ray * /*zwn_ray*/)
 {
   auto self = static_cast<System::Impl *>(data);
   if (!self->delegate_) return;
@@ -169,27 +169,27 @@ System::Impl::HandleRayFrame(void *data, struct zgn_ray * /*zgn_ray*/)
   self->ray_axis_event_ = RayAxisEvent();
 }
 
-const zgn_seat_listener System::Impl::seat_listener_ = {
+const zwn_seat_listener System::Impl::seat_listener_ = {
     System::Impl::HandleSeatCapabilities,
 };
 
 void
 System::Impl::HandleSeatCapabilities(
-    void *data, struct zgn_seat * /*zgn_seat*/, uint32_t capabilities)
+    void *data, struct zwn_seat * /*zwn_seat*/, uint32_t capabilities)
 {
   auto self = static_cast<System::Impl *>(data);
   bool has_ray =
-      (ZGN_SEAT_CAPABILITY_RAY_ORIGIN | ZGN_SEAT_CAPABILITY_RAY_DIRECTION) &
+      (ZWN_SEAT_CAPABILITY_RAY_ORIGIN | ZWN_SEAT_CAPABILITY_RAY_DIRECTION) &
       capabilities;
 
-  if (has_ray && !self->zgn_ray_) {
-    self->zgn_ray_ = zgn_seat_get_ray(self->zgn_seat_);
-    zgn_ray_add_listener(self->zgn_ray_, &System::Impl::ray_listener_, self);
+  if (has_ray && !self->zwn_ray_) {
+    self->zwn_ray_ = zwn_seat_get_ray(self->zwn_seat_);
+    zwn_ray_add_listener(self->zwn_ray_, &System::Impl::ray_listener_, self);
   }
 
-  if (!has_ray && self->zgn_ray_) {
-    zgn_ray_release(self->zgn_ray_);
-    self->zgn_ray_ = nullptr;
+  if (!has_ray && self->zwn_ray_) {
+    zwn_ray_release(self->zwn_ray_);
+    self->zwn_ray_ = nullptr;
   }
 }
 
@@ -203,27 +203,27 @@ System::Impl::HandleGlobal(void *data, struct wl_registry *registry,
     uint32_t name, const char *interface, uint32_t version)
 {
   auto self = static_cast<System::Impl *>(data);
-  if (std::strcmp(interface, "zgn_compositor") == 0) {
-    if (self->zgn_compositor_) zgn_compositor_destroy(self->zgn_compositor_);
-    self->zgn_compositor_ = static_cast<zgn_compositor *>(
-        wl_registry_bind(registry, name, &zgn_compositor_interface, version));
-  } else if (std::strcmp(interface, "zgn_seat") == 0) {
-    if (self->zgn_seat_) zgn_seat_destroy(self->zgn_seat_);
-    self->zgn_seat_ = static_cast<zgn_seat *>(
-        wl_registry_bind(registry, name, &zgn_seat_interface, version));
-    zgn_seat_add_listener(self->zgn_seat_, &System::Impl::seat_listener_, self);
-  } else if (std::strcmp(interface, "zgn_gles_v32") == 0) {
-    if (self->zgn_gles_v32_) zgn_gles_v32_destroy(self->zgn_gles_v32_);
-    self->zgn_gles_v32_ = static_cast<zgn_gles_v32 *>(
-        wl_registry_bind(registry, name, &zgn_gles_v32_interface, version));
-  } else if (std::strcmp(interface, "zgn_shell") == 0) {
-    if (self->zgn_shell_) zgn_shell_destroy(self->zgn_shell_);
-    self->zgn_shell_ = static_cast<zgn_shell *>(
-        wl_registry_bind(registry, name, &zgn_shell_interface, version));
-  } else if (std::strcmp(interface, "zgn_shm") == 0) {
-    if (self->zgn_shm_) zgn_shm_destroy(self->zgn_shm_);
-    self->zgn_shm_ = static_cast<zgn_shm *>(
-        wl_registry_bind(registry, name, &zgn_shm_interface, version));
+  if (std::strcmp(interface, "zwn_compositor") == 0) {
+    if (self->zwn_compositor_) zwn_compositor_destroy(self->zwn_compositor_);
+    self->zwn_compositor_ = static_cast<zwn_compositor *>(
+        wl_registry_bind(registry, name, &zwn_compositor_interface, version));
+  } else if (std::strcmp(interface, "zwn_seat") == 0) {
+    if (self->zwn_seat_) zwn_seat_destroy(self->zwn_seat_);
+    self->zwn_seat_ = static_cast<zwn_seat *>(
+        wl_registry_bind(registry, name, &zwn_seat_interface, version));
+    zwn_seat_add_listener(self->zwn_seat_, &System::Impl::seat_listener_, self);
+  } else if (std::strcmp(interface, "zwn_gles_v32") == 0) {
+    if (self->zwn_gles_v32_) zwn_gles_v32_destroy(self->zwn_gles_v32_);
+    self->zwn_gles_v32_ = static_cast<zwn_gles_v32 *>(
+        wl_registry_bind(registry, name, &zwn_gles_v32_interface, version));
+  } else if (std::strcmp(interface, "zwn_shell") == 0) {
+    if (self->zwn_shell_) zwn_shell_destroy(self->zwn_shell_);
+    self->zwn_shell_ = static_cast<zwn_shell *>(
+        wl_registry_bind(registry, name, &zwn_shell_interface, version));
+  } else if (std::strcmp(interface, "zwn_shm") == 0) {
+    if (self->zwn_shm_) zwn_shm_destroy(self->zwn_shm_);
+    self->zwn_shm_ = static_cast<zwn_shm *>(
+        wl_registry_bind(registry, name, &zwn_shm_interface, version));
   }
 }
 
@@ -250,10 +250,10 @@ System::Impl::TryConnect(const char *socket)
 
   wl_display_roundtrip(display_);
 
-  if (zgn_compositor_ == nullptr || zgn_seat_ == nullptr ||
-      zgn_gles_v32_ == nullptr || zgn_shell_ == nullptr ||
-      zgn_shm_ == nullptr) {
-    LOG_DEBUG("Server does not support zigen protocols");
+  if (zwn_compositor_ == nullptr || zwn_seat_ == nullptr ||
+      zwn_gles_v32_ == nullptr || zwn_shell_ == nullptr ||
+      zwn_shm_ == nullptr) {
+    LOG_DEBUG("Server does not support zwin protocols");
     goto err_globals;
   }
 
@@ -273,20 +273,20 @@ System::Impl::TryConnect(const char *socket)
   return true;
 
 err_globals:
-  if (zgn_shm_) zgn_shm_destroy(zgn_shm_);
-  zgn_shm_ = nullptr;
+  if (zwn_shm_) zwn_shm_destroy(zwn_shm_);
+  zwn_shm_ = nullptr;
 
-  if (zgn_shell_) zgn_shell_destroy(zgn_shell_);
-  zgn_shell_ = nullptr;
+  if (zwn_shell_) zwn_shell_destroy(zwn_shell_);
+  zwn_shell_ = nullptr;
 
-  if (zgn_gles_v32_) zgn_gles_v32_destroy(zgn_gles_v32_);
-  zgn_gles_v32_ = nullptr;
+  if (zwn_gles_v32_) zwn_gles_v32_destroy(zwn_gles_v32_);
+  zwn_gles_v32_ = nullptr;
 
-  if (zgn_seat_) zgn_seat_destroy(zgn_seat_);
-  zgn_seat_ = nullptr;
+  if (zwn_seat_) zwn_seat_destroy(zwn_seat_);
+  zwn_seat_ = nullptr;
 
-  if (zgn_compositor_) zgn_compositor_destroy(zgn_compositor_);
-  zgn_compositor_ = nullptr;
+  if (zwn_compositor_) zwn_compositor_destroy(zwn_compositor_);
+  zwn_compositor_ = nullptr;
 
   wl_registry_destroy(registry_);
   registry_ = nullptr;
@@ -378,11 +378,11 @@ System::Impl::Impl(ISystemDelegate *delegate) : delegate_(delegate) {}
 
 System::Impl::~Impl()
 {
-  if (zgn_shm_) zgn_shm_destroy(zgn_shm_);
-  if (zgn_shell_) zgn_shell_destroy(zgn_shell_);
-  if (zgn_gles_v32_) zgn_gles_v32_destroy(zgn_gles_v32_);
-  if (zgn_seat_) zgn_seat_destroy(zgn_seat_);
-  if (zgn_compositor_) zgn_compositor_destroy(zgn_compositor_);
+  if (zwn_shm_) zwn_shm_destroy(zwn_shm_);
+  if (zwn_shell_) zwn_shell_destroy(zwn_shell_);
+  if (zwn_gles_v32_) zwn_gles_v32_destroy(zwn_gles_v32_);
+  if (zwn_seat_) zwn_seat_destroy(zwn_seat_);
+  if (zwn_compositor_) zwn_compositor_destroy(zwn_compositor_);
   if (registry_) wl_registry_destroy(registry_);
   if (display_) wl_display_disconnect(display_);
 }

--- a/src/system.h
+++ b/src/system.h
@@ -3,9 +3,9 @@
 #include <zukou.h>
 
 #include <wayland-client.h>
-#include <zigen-client-protocol.h>
-#include <zigen-gles-v32-client-protocol.h>
-#include <zigen-shell-client-protocol.h>
+#include <zwin-client-protocol.h>
+#include <zwin-gles-v32-client-protocol.h>
+#include <zwin-shell-client-protocol.h>
 
 #include "loop.h"
 
@@ -21,11 +21,11 @@ class System::Impl
   ~Impl();
 
   inline Loop *loop();
-  inline zgn_compositor *compositor();
-  inline zgn_seat *seat();
-  inline zgn_gles_v32 *gles_v32();
-  inline zgn_shell *shell();
-  inline zgn_shm *shm();
+  inline zwn_compositor *compositor();
+  inline zwn_seat *seat();
+  inline zwn_gles_v32 *gles_v32();
+  inline zwn_shell *shell();
+  inline zwn_shm *shm();
 
  private:
   static const wl_registry_listener registry_listener_;
@@ -35,29 +35,29 @@ class System::Impl
   static void HandleGlobalRemove(
       void *data, struct wl_registry *wl_registry, uint32_t name);
 
-  static const struct zgn_seat_listener seat_listener_;
+  static const struct zwn_seat_listener seat_listener_;
   static void HandleSeatCapabilities(
-      void *data, struct zgn_seat *zgn_seat, uint32_t capabilities);
+      void *data, struct zwn_seat *zwn_seat, uint32_t capabilities);
 
-  static const struct zgn_ray_listener ray_listener_;
-  static void HandleRayEnter(void *data, struct zgn_ray *zgn_ray,
-      uint32_t serial, struct zgn_virtual_object *virtual_object,
+  static const struct zwn_ray_listener ray_listener_;
+  static void HandleRayEnter(void *data, struct zwn_ray *zwn_ray,
+      uint32_t serial, struct zwn_virtual_object *virtual_object,
       struct wl_array *origin, struct wl_array *direction);
-  static void HandleRayLeave(void *data, struct zgn_ray *zgn_ray,
-      uint32_t serial, struct zgn_virtual_object *virtual_object);
-  static void HandleRayMotion(void *data, struct zgn_ray *zgn_ray,
+  static void HandleRayLeave(void *data, struct zwn_ray *zwn_ray,
+      uint32_t serial, struct zwn_virtual_object *virtual_object);
+  static void HandleRayMotion(void *data, struct zwn_ray *zwn_ray,
       uint32_t time, struct wl_array *origin, struct wl_array *direction);
-  static void HandleRayButton(void *data, struct zgn_ray *zgn_ray,
+  static void HandleRayButton(void *data, struct zwn_ray *zwn_ray,
       uint32_t serial, uint32_t time, uint32_t button, uint32_t state);
-  static void HandleRayAxis(void *data, struct zgn_ray *zgn_ray, uint32_t time,
+  static void HandleRayAxis(void *data, struct zwn_ray *zwn_ray, uint32_t time,
       uint32_t axis, wl_fixed_t value);
   static void HandleRayAxisSource(
-      void *data, struct zgn_ray *zgn_ray, uint32_t axis_source);
+      void *data, struct zwn_ray *zwn_ray, uint32_t axis_source);
   static void HandleRayAxisStop(
-      void *data, struct zgn_ray *zgn_ray, uint32_t time, uint32_t axis);
+      void *data, struct zwn_ray *zwn_ray, uint32_t time, uint32_t axis);
   static void HandleRayAxisDiscrete(
-      void *data, struct zgn_ray *zgn_ray, uint32_t axis, int32_t discrete);
-  static void HandleRayFrame(void *data, struct zgn_ray *zgn_ray);
+      void *data, struct zwn_ray *zwn_ray, uint32_t axis, int32_t discrete);
+  static void HandleRayFrame(void *data, struct zwn_ray *zwn_ray);
 
   bool TryConnect(const char *socket /*nonnull*/);
 
@@ -68,13 +68,13 @@ class System::Impl
   wl_display *display_ = nullptr;
   wl_registry *registry_ = nullptr;
 
-  zgn_compositor *zgn_compositor_ = nullptr;
-  zgn_seat *zgn_seat_ = nullptr;
-  zgn_gles_v32 *zgn_gles_v32_ = nullptr;
-  zgn_shell *zgn_shell_ = nullptr;
-  zgn_shm *zgn_shm_ = nullptr;
+  zwn_compositor *zwn_compositor_ = nullptr;
+  zwn_seat *zwn_seat_ = nullptr;
+  zwn_gles_v32 *zwn_gles_v32_ = nullptr;
+  zwn_shell *zwn_shell_ = nullptr;
+  zwn_shm *zwn_shm_ = nullptr;
 
-  zgn_ray *zgn_ray_ = nullptr;  // nullable
+  zwn_ray *zwn_ray_ = nullptr;  // nullable
 
   RayAxisEvent ray_axis_event_;
 
@@ -88,34 +88,34 @@ System::Impl::loop()
   return &loop_;
 }
 
-inline zgn_compositor *
+inline zwn_compositor *
 System::Impl::compositor()
 {
-  return zgn_compositor_;
+  return zwn_compositor_;
 }
 
-inline zgn_seat *
+inline zwn_seat *
 System::Impl::seat()
 {
-  return zgn_seat_;
+  return zwn_seat_;
 }
 
-inline zgn_gles_v32 *
+inline zwn_gles_v32 *
 System::Impl::gles_v32()
 {
-  return zgn_gles_v32_;
+  return zwn_gles_v32_;
 }
 
-inline zgn_shell *
+inline zwn_shell *
 System::Impl::shell()
 {
-  return zgn_shell_;
+  return zwn_shell_;
 }
 
-inline zgn_shm *
+inline zwn_shm *
 System::Impl::shm()
 {
-  return zgn_shm_;
+  return zwn_shm_;
 }
 
 }  // namespace zukou


### PR DESCRIPTION
## Context

To coincide with a organization name change, replace `zigen` -> `zwin`

## How to check behavior

Build and install. Try building zennist.